### PR TITLE
fix: md content issue in ssr #2

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,48 +1,50 @@
 ---
-import { type CollectionEntry, getCollection } from 'astro:content';
-import Layout from '../../layouts/Layout.astro';
-import { render } from 'astro:content';
+import { type CollectionEntry, getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import { render, getEntry } from "astro:content";
 import { Breadcrumbs } from "astro-breadcrumbs";
 import "astro-breadcrumbs/breadcrumbs.css";
 
-export async function getStaticPaths() {
-	const posts = await getCollection('blog');
-	return posts.map((post) => ({
-		params: { slug: post.id },
-		props: post,
-	}));
+const slug = Astro.params.slug;
+const entry = await getEntry("blog", slug);
+let slugval = "/blog/" + slug;
+if (!entry) {
+  // Handle Error, for example:
+  throw new Error("Could not find data");
 }
-type Props = CollectionEntry<'blog'>;
-
-const post = Astro.props;
-const { Content } = await render(post);
+const { Content } = await render(entry);
 ---
 
-<Layout {...post.data}>
-	<div class="w-full mx-auto flex flex-col min-h-screen bg-gray-100">
-		<!-- Main Content -->
-		<main class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6 min-h-[70vh]">
-			<Breadcrumbs linkTextFormat="capitalized"  ariaLabel="Site navigation" separatorAriaHidden={false}
-			>
-			<svg
-			slot="separator"
-			xmlns="http://www.w3.org/2000/svg"
-			width="24"
-			height="24"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			><polyline points="9 18 15 12 9 6"></polyline>
-			</svg>
-			</Breadcrumbs>
-		  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-			<!-- Page Title -->
-			<h1 class="text-4xl font-bold text-center mb-12">{post.data.title}</h1>
-			<Content />
-		   </div>
-		</main>
-	</div>
+<Layout {...entry.data}>
+  <div class="w-full mx-auto flex flex-col min-h-screen bg-gray-100">
+    <!-- Main Content -->
+    <main
+      class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6 min-h-[70vh]"
+    >
+      <Breadcrumbs
+        linkTextFormat="capitalized"
+        ariaLabel="Site navigation"
+        separatorAriaHidden={false}
+      >
+        <svg
+          slot="separator"
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          ><polyline points="9 18 15 12 9 6"></polyline>
+        </svg>
+      </Breadcrumbs>
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <!-- Page Title -->
+        <h1 class="text-4xl font-bold text-center mb-12">{entry.data.title}</h1>
+        <Content />
+      </div>
+    </main>
+  </div>
 </Layout>

--- a/src/pages/expectations/[...slug].astro
+++ b/src/pages/expectations/[...slug].astro
@@ -1,51 +1,54 @@
 ---
-import { type CollectionEntry, getCollection } from 'astro:content';
-import { render } from 'astro:content';
-import Layout from '../../layouts/Layout.astro';
-import Sidebar from '../../components/Sidebar';
-import {buildMenuTree} from '../../utils/helper.astro';
+import { render, getEntry } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import Sidebar from "../../components/Sidebar";
+import { buildMenuTree } from "../../utils/helper.astro";
 import { Breadcrumbs } from "astro-breadcrumbs";
 import "astro-breadcrumbs/breadcrumbs.css";
-import MarkdownEditor from '../../components/ContentEditor';
-import EditButton from '../../components/EditMarkdownButton';
+import MarkdownEditor from "../../components/ContentEditor";
+import EditButton from "../../components/EditMarkdownButton";
 
-const files = import.meta.glob('/src/content/expectations/**/*.{md,mdx}', { eager: true });
+const files = import.meta.glob("/src/content/expectations/**/*.{md,mdx}", {
+  eager: true,
+});
 const dirName = "expectations";
 // Build the menu tree
-const menuTree = buildMenuTree(files,dirName);
+const menuTree = buildMenuTree(files, dirName);
 
-export async function getStaticPaths() {
-	const posts = await getCollection('expectations');
-	return posts.map((post) => ({
-		params: { slug: post.id },
-		props: post,
-	}));
+const slug = Astro.params.slug;
+const entry = await getEntry("expectations", slug);
+let slugval = "/expectations/" + slug;
+if (!entry) {
+  // Handle Error, for example:
+  throw new Error("Could not find data");
 }
-type Props = CollectionEntry<'expectations'>;
+const { Content, headings, remarkPluginFrontmatter } = await render(entry);
 
-const post = Astro.props;
-const { Content } = await render(post);
-const rawMarkdownContent = post.body; // Adjust if raw content is in another property
-
-const slug = post.id;
-let slugval = '/expectations/' + slug;
+const rawMarkdownContent = entry.body; // Adjust if raw content is in another property
 
 ---
-<Layout>	
 
-<main class="max-w-full mx-auto min-h-[70vh] grid grid-cols-12 gap-6 flex">
-      <div class="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 bg-white p-3 shadow-xs">
-        <div id="starlight__sidebar" class="sidebar-pane">
-          <div class="sidebar-content">
-            <div class="sidebar sl-flex sidebar-left-menu font-medium text-base">
+<Layout>
+  <main class="max-w-full mx-auto min-h-[70vh] grid grid-cols-12 gap-6 flex">
+    <div
+      class="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 bg-white p-3 shadow-xs"
+    >
+      <div id="starlight__sidebar" class="sidebar-pane">
+        <div class="sidebar-content">
+          <div class="sidebar sl-flex sidebar-left-menu font-medium text-base">
             <Sidebar menuTree={menuTree} slugval={slugval} />
-            </div>
           </div>
         </div>
       </div>
-      <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 pb-5 pt-0 md:pt-5 px-5 md:px-0 md:pr-5">
-        <Breadcrumbs linkTextFormat="capitalized"  ariaLabel="Site navigation" separatorAriaHidden={false}
-        >
+    </div>
+    <div
+      class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 pb-5 pt-0 md:pt-5 px-5 md:px-0 md:pr-5"
+    >
+      <Breadcrumbs
+        linkTextFormat="capitalized"
+        ariaLabel="Site navigation"
+        separatorAriaHidden={false}
+      >
         <svg
           slot="separator"
           xmlns="http://www.w3.org/2000/svg"
@@ -59,45 +62,45 @@ let slugval = '/expectations/' + slug;
           stroke-linejoin="round"
           ><polyline points="9 18 15 12 9 6"></polyline>
         </svg>
-        </Breadcrumbs>
-        <div class="border-b border-slate-300 pb-3 mb-4">
-          <div class="flex items-center justify-between">
-            <h1 class="text-2xl lg:text-4xl font-bold text-slate-700 mt-4 mb-1">
-              {post.data.title}
-            </h1>
-            <EditButton client:only="react" />
-          </div>
+      </Breadcrumbs>
+      <div class="border-b border-slate-300 pb-3 mb-4">
+        <div class="flex items-center justify-between">
+          <h1 class="text-2xl lg:text-4xl font-bold text-slate-700 mt-4 mb-1">
+            {entry.data.title}
+          </h1>
+          <EditButton client:only="react" />
         </div>
+      </div>
 
-        {
-          (
-            <article class="prose max-w-screen-xl withbullet">
-              <span id="markdown-content" style="display:none">
-                <MarkdownEditor bodyContent={rawMarkdownContent} client:only="react" />
+      {
+        (
+          <article class="prose max-w-screen-xl withbullet">
+            <span id="markdown-content" style="display:none">
+              <MarkdownEditor
+                bodyContent={rawMarkdownContent}
+                client:only="react"
+              />
 
-                <div class="md:col-span-3 text-right">
-                  <button
-                    type="button"
-                    class="relative mt-3 inline-flex items-center gap-x-1.5 rounded text-white px-3 py-2 font-semibold ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10 text-sm"
-                    style="background-color: black;"
-                  >
-                    Save
-                  </button>
-                </div>
-              </span>
-              <span id="html-content">
-                <Content />
-              </span>
-            
-            </article>
-          )
-        }
+              <div class="md:col-span-3 text-right">
+                <button
+                  type="button"
+                  class="relative mt-3 inline-flex items-center gap-x-1.5 rounded text-white px-3 py-2 font-semibold ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10 text-sm"
+                  style="background-color: black;"
+                >
+                  Save
+                </button>
+              </div>
+            </span>
+            <span id="html-content">
+              <Content />
+            </span>
+          </article>
+        )
+      }
 
       <article class="prose max-w-screen-xl withbullet markdown-content">
         <Content />
       </article>
-      </div>
+    </div>
   </main>
 </Layout>
-
-

--- a/src/pages/outcomes/[...slug].astro
+++ b/src/pages/outcomes/[...slug].astro
@@ -1,68 +1,71 @@
 ---
-import { type CollectionEntry, getCollection } from 'astro:content';
-import { render } from 'astro:content';
-import Layout from '../../layouts/Layout.astro';
-import Sidebar from '../../components/Sidebar';
-import {buildMenuTree} from '../../utils/helper.astro';
+import { type CollectionEntry, getCollection } from "astro:content";
+import { render, getEntry } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import Sidebar from "../../components/Sidebar";
+import { buildMenuTree } from "../../utils/helper.astro";
 import { Breadcrumbs } from "astro-breadcrumbs";
 import "astro-breadcrumbs/breadcrumbs.css";
 
-const files = import.meta.glob('/src/content/outcomes/**/*.{md,mdx}', { eager: true });
+const files = import.meta.glob("/src/content/outcomes/**/*.{md,mdx}", {
+  eager: true,
+});
 // Build the menu tree
-const menuTree = buildMenuTree(files,"outcomes");
+const menuTree = buildMenuTree(files, "outcomes");
 
-export async function getStaticPaths() {
-	const posts = await getCollection('outcomes');
-	return posts.map((post) => ({
-		params: { slug: post.id },
-		props: post,
-	}));
+const slug = Astro.params.slug;
+const entry = await getEntry("outcomes", slug);
+let slugval = "/outcomes/" + slug;
+if (!entry) {
+  // Handle Error, for example:
+  throw new Error("Could not find data");
 }
-type Props = CollectionEntry<'outcomes'>;
-
-const post = Astro.props;
-const { Content } = await render(post);
-const slug = post.id;
-let slugval = '/outcomes/' + slug;
-
+const { Content } = await render(entry);
 ---
-<Layout>	
 
-<main class="max-w-full mx-auto min-h-[70vh] grid grid-cols-12 gap-6 flex">
-  <div class="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 bg-white p-3 shadow-xs">
-    <div id="starlight__sidebar" class="sidebar-pane">
-      <div class="sidebar-content">
-        <div class="sidebar sl-flex sidebar-left-menu font-medium text-base">
-        <Sidebar menuTree={menuTree} slugval={slugval} />
+<Layout>
+  <main class="max-w-full mx-auto min-h-[70vh] grid grid-cols-12 gap-6 flex">
+    <div
+      class="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 bg-white p-3 shadow-xs"
+    >
+      <div id="starlight__sidebar" class="sidebar-pane">
+        <div class="sidebar-content">
+          <div class="sidebar sl-flex sidebar-left-menu font-medium text-base">
+            <Sidebar menuTree={menuTree} slugval={slugval} />
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 pb-5 pt-0 md:pt-5 px-5 md:px-0 md:pr-5">
-    <Breadcrumbs linkTextFormat="capitalized"  ariaLabel="Site navigation" separatorAriaHidden={false}
+    <div
+      class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 pb-5 pt-0 md:pt-5 px-5 md:px-0 md:pr-5"
     >
-    <svg
-      slot="separator"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      ><polyline points="9 18 15 12 9 6"></polyline>
-    </svg>
-    </Breadcrumbs>
-    <div class="border-b border-slate-300 pb-3 mb-4">
-    <h1 class="text-2xl lg:text-4xl font-bold text-slate-700 mt-4 mb-1">{post.data.title}</h1>
+      <Breadcrumbs
+        linkTextFormat="capitalized"
+        ariaLabel="Site navigation"
+        separatorAriaHidden={false}
+      >
+        <svg
+          slot="separator"
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          ><polyline points="9 18 15 12 9 6"></polyline>
+        </svg>
+      </Breadcrumbs>
+      <div class="border-b border-slate-300 pb-3 mb-4">
+        <h1 class="text-2xl lg:text-4xl font-bold text-slate-700 mt-4 mb-1">
+          {entry.data.title}
+        </h1>
+      </div>
+      <article class="prose max-w-screen-xl withbullet markdown-content">
+        <Content />
+      </article>
     </div>
-  <article class="prose max-w-screen-xl withbullet markdown-content">
-    <Content />
-  </article>
-  </div>
-</main>
+  </main>
 </Layout>
-
-

--- a/src/pages/progress/[...slug].astro
+++ b/src/pages/progress/[...slug].astro
@@ -1,46 +1,63 @@
 ---
-import { type CollectionEntry, getCollection } from 'astro:content';
-import { render } from 'astro:content';
-import Layout from '../../layouts/Layout.astro';
-import Sidebar from '../../components/Sidebar';
-import {buildMenuTree} from '../../utils/helper.astro';
+import { type CollectionEntry, getCollection } from "astro:content";
+import { render, getEntry } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import Sidebar from "../../components/Sidebar";
+import { buildMenuTree } from "../../utils/helper.astro";
 import { Breadcrumbs } from "astro-breadcrumbs";
 import "astro-breadcrumbs/breadcrumbs.css";
 
-const files = import.meta.glob('/src/content/progress/**/*.{md,mdx}', { eager: true });
+const files = import.meta.glob("/src/content/progress/**/*.{md,mdx}", {
+  eager: true,
+});
 const dirName = "progress";
-const menuTree = buildMenuTree(files,dirName);
+const menuTree = buildMenuTree(files, dirName);
 
-export async function getStaticPaths() {
-	const posts = await getCollection('progress');
-	return posts.map((post) => ({
-		params: { slug: post.id },
-		props: post,
-	}));
+const slug = Astro.params.slug;
+const entry = await getEntry("progress", slug);
+let slugval = "/progress/" + slug;
+if (!entry) {
+  // Handle Error, for example:
+  throw new Error("Could not find data");
 }
-type Props = CollectionEntry<'progress'>;
+const { Content } = await render(entry);
 
-const post = Astro.props;
-const { Content } = await render(post);
-const slug = post.id;
-let slugval = '/progress/' + slug;
+// export async function getStaticPaths() {
+//   const posts = await getCollection("progress");
+//   return posts.map((post) => ({
+//     params: { slug: post.id },
+//     props: post,
+//   }));
+// }
+// type Props = CollectionEntry<"progress">;
 
+// const post = Astro.props;
+// const { Content } = await render(post);
+// const slug = post.id;
+// let slugval = "/progress/" + slug;
 ---
-<Layout>	
 
-<main class="max-w-full mx-auto min-h-[70vh] grid grid-cols-12 gap-6 flex">
-      <div class="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 bg-white p-3 shadow-xs">
-        <div id="starlight__sidebar" class="sidebar-pane">
-          <div class="sidebar-content">
-            <div class="sidebar sl-flex sidebar-left-menu font-medium text-base">
+<Layout>
+  <main class="max-w-full mx-auto min-h-[70vh] grid grid-cols-12 gap-6 flex">
+    <div
+      class="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 bg-white p-3 shadow-xs"
+    >
+      <div id="starlight__sidebar" class="sidebar-pane">
+        <div class="sidebar-content">
+          <div class="sidebar sl-flex sidebar-left-menu font-medium text-base">
             <Sidebar menuTree={menuTree} slugval={slugval} />
-            </div>
           </div>
         </div>
       </div>
-      <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 pb-5 pt-0 md:pt-5 px-5 md:px-0 md:pr-5">
-        <Breadcrumbs linkTextFormat="capitalized"  ariaLabel="Site navigation" separatorAriaHidden={false}
-        >
+    </div>
+    <div
+      class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 pb-5 pt-0 md:pt-5 px-5 md:px-0 md:pr-5"
+    >
+      <Breadcrumbs
+        linkTextFormat="capitalized"
+        ariaLabel="Site navigation"
+        separatorAriaHidden={false}
+      >
         <svg
           slot="separator"
           xmlns="http://www.w3.org/2000/svg"
@@ -54,15 +71,15 @@ let slugval = '/progress/' + slug;
           stroke-linejoin="round"
           ><polyline points="9 18 15 12 9 6"></polyline>
         </svg>
-        </Breadcrumbs>
-        <div class="border-b border-slate-300 pb-3 mb-4">
-        <h1 class="text-2xl lg:text-4xl font-bold text-slate-700 mt-4 mb-1">{post.data.title}</h1>
-        </div>
+      </Breadcrumbs>
+      <div class="border-b border-slate-300 pb-3 mb-4">
+        <h1 class="text-2xl lg:text-4xl font-bold text-slate-700 mt-4 mb-1">
+          {entry.data.title}
+        </h1>
+      </div>
       <article class="prose max-w-screen-xl withbullet markdown-content">
         <Content />
       </article>
-      </div>
+    </div>
   </main>
 </Layout>
-
-


### PR DESCRIPTION
This PR addresses a critical issue encountered after migrating from Static Site Generation (SSG) to Server-Side Rendering (SSR). The issue resulted in the error:  
`Cannot read properties of undefined (reading 'title')`  
This was due to the `getCollection` method not functioning as expected in SSR. 

#### Changes:
1. Replaced the usage of `getCollection` with Astro's `getEntry` method to fetch the Markdown content correctly in SSR.
