### PR TITLE
feat: add support for ZITADEL authentication with sample .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Enable/Disabl default Authentication Features
+ENABLE_DEFAULT_AUTH=false # Set to 'true' to enable default authentication
+
+# Enable/Disable ZITADEL Authentication Features
+ENABLE_ZITADEL_AUTH=true  # Set to 'true' to enable ZITADEL authentication
+
+# ZITADEL Configuration
+PUBLIC_ZITADEL_CLIENT_ID="your-zitadel-client-id"
+PUBLIC_ZITADEL_AUTHORITY="https://your-zitadel-authority-url"
+PUBLIC_ZITADEL_REDIRECT_URI="http://redirecturi/post-authorization/"
+PUBLIC_ZITADEL_LOGOUT_REDIRECT_URI="http://redirecturi/"
+PUBLIC_ZITADEL_ORGANIZATION_ID="your-zitadel-organization-id"
+PUBLIC_ZITADEL_PROJECT_ID="your-zitadel-project-id"
+
+# GITHub
+PUBLIC_GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxx
+PUBLIC_GITHUB_REPO_NAME=xxxxxxxxxxx
+PUBLIC_GITHUB_OWNER_NAME=xxxxx

--- a/README-Theme.md
+++ b/README-Theme.md
@@ -1,7 +1,7 @@
 # EOH Astro 5 Theme  
 
 ## Overview  
-The EOH Astro 5 Theme is a highly customizable and versatile Astro-based theme. It comes with built-in components like breadcrumbs, a header, footer, and sidebar for seamless navigation. The theme supports dynamic content creation, including features for expectations and outcomes, blog collections, landing pages, static pages, and integration with GitHub Discussions Blog Loader. 
+The EOH Astro 5 Theme is a highly customizable and versatile Astro-based theme. It comes with built-in components like breadcrumbs, a header, footer, and sidebar for seamless navigation. The theme supports dynamic content creation, including features for expectations and outcomes, blog collections, landing pages, static pages, and integration with GitHub Discussions Blog Loader.  
 
 ## Features  
 - **Header and Footer**: Easily customizable components.  
@@ -14,210 +14,124 @@ The EOH Astro 5 Theme is a highly customizable and versatile Astro-based theme. 
 - **Landing Page**: Includes cards, mission, and vision sections etc.  
 - **Custom Pages**: Easily add new pages as needed.  
 
+## GitHub Discussions  
 
-## GitHub Discussions 
+This project demonstrates how to integrate GitHub Discussions into an Astro site using the `github-discussions-blog-loader`.  
 
-This project demonstrates how to integrate GitHub Discussions into an Astro site using the `github-discussions-blog-loader`.
+## Setup  
 
-## Setup
+### Setting Up Environment Variables  
 
-To use the GitHub Discussions loader, follow these steps:
+1. Copy the `.env.example` file to `.env`:  
+   ```bash
+   cp .env.example .env
+   ```  
 
-#### 1. Provide Environment Variables
+To use the GitHub Discussions loader, follow these steps:  
 
-Ensure the following environment variables are set in your project. You can create a `.env` file in the root of your project and add these values:
+#### 1. Provide Environment Variables  
 
-PUBLIC_GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxx
+Ensure the following environment variables are set in your project. You can create a `.env` file in the root of your project and add these values:  
 
-PUBLIC_GITHUB_REPO_NAME=xxxxxxxxxxx
+- `PUBLIC_GITHUB_TOKEN`: A GitHub Personal Access Token with read access to discussions.  
+- `PUBLIC_GITHUB_REPO_NAME`: The name of the GitHub repository.  
+- `PUBLIC_GITHUB_OWNER_NAME`: The owner of the GitHub repository (user or organization).  
 
-PUBLIC_GITHUB_OWNER_NAME=xxxxx
+```env
+PUBLIC_GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxx  
+PUBLIC_GITHUB_REPO_NAME=xxxxxxxxxxx  
+PUBLIC_GITHUB_OWNER_NAME=xxxxx  
+```  
 
-PUBLIC_GITHUB_TOKEN: A GitHub Personal Access Token with read access to discussions.
+#### 2. Use the Component  
 
-PUBLIC_GITHUB_REPO_NAME: The name of the GitHub repository.
+You can call the GitHub Discussions loader component in your Astro files. The component is located at:  
 
-PUBLIC_GITHUB_OWNER_NAME: The owner of the GitHub repository (user or organization).
+`src/components/github_discussion/githubDiscussion.astro`  
 
-#### 2. Use the Component
+#### Example Usage  
 
-You can call the GitHub Discussions loader component in your Astro files. The component is located at:
-
-`src/components/github_discussion/githubDiscussion.astro`
-
-#### Example Usage
-
-To use the loader, import the component and include it in your template:
+To use the loader, import the component and include it in your template:  
 
 ```astro
----
-import GithubDiscussionLoader from "../components/github_discussion/githubDiscussion.astro";
----
+---  
+import GithubDiscussionLoader from "../components/github_discussion/githubDiscussion.astro";  
+---  
 
-<GithubDiscussionLoader />
+<GithubDiscussionLoader />  
+```  
 
-```
+## ZITADEL Authentication Component  
 
-## ZITADEL Authentication Component
+You can use the ZITADEL authentication component in your Astro files. The component is located at:  
 
-You can use the ZITADEL authentication component in your Astro files. The component is located at:
+`src/components/zitadel-authentication`  
 
-`src/components/zitadel-authentication`
+### Update `.env` File with the Following Values  
 
+```env
+PUBLIC_ZITADEL_CLIENT_ID="xxxxxxxxx"  
+PUBLIC_ZITADEL_AUTHORITY="xxxxxxxxx"  
+PUBLIC_ZITADEL_REDIRECT_URI="xxxxxxxxx"  
+PUBLIC_ZITADEL_LOGOUT_REDIRECT_URI="xxxxxxxxx"  
+PUBLIC_ZITADEL_ORGANIZATION_ID="xxxxxxxxx"  
+PUBLIC_ZITADEL_PROJECT_ID="xxxxxxxxx"  
 
-## Update env file with following values
+# Enable or disable ZITADEL authentication
+ENABLE_ZITADEL_AUTH=true
+```  
 
-PUBLIC_ZITADEL_CLIENT_ID="xxxxxxxxx"
+### Example Usage  
 
-PUBLIC_ZITADEL_AUTHORITY="xxxxxxxxx"
-
-PUBLIC_ZITADEL_REDIRECT_URI="xxxxxxxxx"
-
-PUBLIC_ZITADEL_LOGOUT_REDIRECT_URI="xxxxxxxxx"
-
-PUBLIC_ZITADEL_ORGANIZATION_ID="xxxxxxxxx"
-
-PUBLIC_ZITADEL_PROJECT_ID="xxxxxxxxx"
-
-## Example Usage
-
-To use the authentication component, import it and include it in your template:
+To use the authentication component, import it and include it in your template:  
 
 ```astro
----
-import { Authentication } from "../components/zitadel-authentication";
----
-```
+---  
+import { Authentication } from "../components/zitadel-authentication";  
+import { zitadelConfig } from "../utils/env";  
+---  
+```  
 
-## Login Example
-```
-<Authentication
-  clientId={clientId}
-  authority={authority}
-  redirectUri={redirectUri}
-  postLogoutRedirectUri={postLogoutRedirectUri}
-  organizationId={organizationId}
-  projectId={projectId}
-  operation="login"
-/>
-```
+#### Login Example  
 
-## Logout Example
-```
-<Authentication
-  clientId={clientId}
-  authority={authority}
-  redirectUri={redirectUri}
-  postLogoutRedirectUri={postLogoutRedirectUri}
-  organizationId={organizationId}
-  projectId={projectId}
-  operation="logout"
-/>
-```
-## Default Login Credentials for Demo
+```astro
+<Authentication  
+  clientId={zitadelConfig.clientId}  
+  authority={zitadelConfig.authority}  
+  redirectUri={zitadelConfig.redirectUri}  
+  postLogoutRedirectUri={zitadelConfig.postLogoutRedirectUri}  
+  organizationId={zitadelConfig.organizationId}  
+  projectId={zitadelConfig.projectId}  
+  operation="login"  
+/>  
+```  
 
-| User Name | Password       |
-|-----------|----------------|
-| EOHdemo   | Demo@eoh1234   |
+#### Logout Example  
 
-## Getting Started  
+```astro
+<Authentication  
+  clientId={zitadelConfig.clientId}  
+  authority={zitadelConfig.authority}  
+  redirectUri={zitadelConfig.redirectUri}  
+  postLogoutRedirectUri={zitadelConfig.postLogoutRedirectUri}  
+  organizationId={zitadelConfig.organizationId}  
+  projectId={zitadelConfig.projectId}  
+  operation="logout"  
+/>  
+```  
 
-1. **Clone the Repository**  
-   ```bash
-   git clone <repository-url>  
-   cd <repository-directory>
-   
-2. **Install Dependencies**  
-   ```bash
-   pnpm install
+### Enabling/Disabling ZITADEL Authentication  
 
-3. **Start the development server**  
-   ```bash
-   pnpm run dev
+You can enable or disable ZITADEL authentication by setting the `ENABLE_ZITADEL_AUTH` environment variable in your `.env` file:  
 
-4. **Build the site**  
-   ```bash
-   pnpm run build
+- **Enable**: `ENABLE_ZITADEL_AUTH=true`  
+- **Disable**: `ENABLE_ZITADEL_AUTH=false`  
 
+## Default Login Credentials for Demo  
 
-## Folder Structure  
-
-```text
-├── LICENSE
-├── README-Theme.md
-├── README.md
-├── astro.config.mjs
-├── package.json
-├── pnpm-lock.yaml
-├── public
-│   └── assets
-│       ├── images
-│       └── styles
-├── src
-│   ├── components
-│   │   ├── ContentEditor.tsx
-│   │   ├── EditMarkdownButton.jsx
-│   │   ├── LatestUpdates.astro
-│   │   ├── Sidebar.tsx
-│   │   ├── github_discussion
-│   │   │   ├── githubDiscussion.astro
-│   │   │   ├── githubDiscussionDetails.tsx
-│   │   │   └── githubDisscussion.tsx
-│   │   └── zitadel-authentication
-│   │       ├── index.js
-│   │       ├── login.jsx
-│   │       └── zitadelAuthentication.astro
-│   ├── content
-│   │   ├── blog
-│   │   ├── expectations
-│   │   ├── outcomes
-│   │   └── progress
-│   ├── content.config.ts
-│   ├── layouts
-│   │   ├── Footer.astro
-│   │   ├── Header.astro
-│   │   ├── Layout.astro
-│   │   └── NavLink.astro
-│   ├── middleware
-│   │   └── index.ts
-│   ├── pages
-│   │   ├── blog
-│   │   │   ├── [...slug].astro
-│   │   │   └── index.astro
-│   │   ├── contact
-│   │   │   └── index.astro
-│   │   ├── discussions
-│   │   │   └── index.astro
-│   │   ├── expectations
-│   │   │   ├── [...slug].astro
-│   │   │   └── index.astro
-│   │   ├── index.astro
-│   │   ├── logout.astro
-│   │   ├── mission-vision
-│   │   │   └── index.astro
-│   │   ├── outcomes
-│   │   │   ├── [...slug].astro
-│   │   │   └── index.astro
-│   │   ├── post-authorization.astro
-│   │   └── progress
-│   │       ├── [...slug].astro
-│   │       └── index.astro
-│   └── utils
-│       └── helper.astro
-├── support
-│   └── ci-cd.sh
-├── tailwind.config.js
-├── tsconfig.json
-└── visualizing-expectations-outcomes.md
-```
-- **`src/components`**: Contains the header, footer, and sidebar components.  
-- **`src/content`**: Add items here for generating sidebar menus.  
-- **`src/pages`**: Add or update pages (e.g., blog, landing page, mission, vision).  
-
-## Customization  
-- Update `header` and `footer` components as needed.  
-- Add or modify pages in the `src/pages` folder.  
-- Customize sidebar menu items via `src/content`.  
+| User Name | Password       |  
+|-----------|----------------|  
+| EOHdemo   | Demo@eoh1234   |  
 
 ---
 

--- a/src/layouts/Header.astro
+++ b/src/layouts/Header.astro
@@ -1,5 +1,6 @@
 ---
 const currentPath = Astro.url.pathname;
+import { isZitadelEnabled } from "../utils/env";
 ---
 
 <header class="bg-white shadow-sm border-b">
@@ -107,13 +108,20 @@ const currentPath = Astro.url.pathname;
               >Profile</a
             >
           </li>
-          <li>
-            <a
-              href="/logout"
-              class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-              >Sign out</a
-            >
-          </li>
+          {
+            isZitadelEnabled ? (
+              <li>
+                <a
+                  href="/logout"
+                  class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                >
+                  Sign out
+                </a>
+              </li>
+            ) : (
+              ""
+            )
+          }
         </ul>
       </div>
     </div>

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,18 +1,24 @@
 import type { MiddlewareHandler, AstroCookies } from "astro";
 import { defineMiddleware, sequence } from "astro/middleware";
+import { isZitadelEnabled, zitadelConfig } from '../utils/env';
 const middleware: MiddlewareHandler = defineMiddleware((context, next) => {
     const authStateCookie = context.cookies.get("authState")?.value;
     const organizationName = context.cookies.get("organizationName")?.value;
     const { pathname } = context.url;
 
-    if (pathname == '/post-authorization/') {
-        return next();
-    }
-    else if (authStateCookie === undefined && pathname != '/logout') {
-        return context.redirect("/logout");
+    if (isZitadelEnabled) {
+        if (pathname == '/post-authorization/') {
+            return next();
+        }
+        else if (authStateCookie === undefined && pathname != '/logout') {
+            return context.redirect("/logout");
+        } else {
+            return next();
+        }
     } else {
         return next();
     }
+
 
 
 });

--- a/src/pages/logout.astro
+++ b/src/pages/logout.astro
@@ -1,20 +1,15 @@
 ---
 import { Authentication } from "../components/zitadel-authentication";
-const envData = import.meta.env;
-const clientId = envData.PUBLIC_ZITADEL_CLIENT_ID;
-const authority = envData.PUBLIC_ZITADEL_AUTHORITY;
-const redirectUri = envData.PUBLIC_ZITADEL_REDIRECT_URI;
-const postLogoutRedirectUri = envData.PUBLIC_ZITADEL_LOGOUT_REDIRECT_URI;
-const organizationId = envData.PUBLIC_ZITADEL_ORGANIZATION_ID;
-const projectId = envData.PUBLIC_ZITADEL_PROJECT_ID;
+import { zitadelConfig } from "../utils/env";
+
 ---
 
 <Authentication
-  clientId={clientId}
-  authority={authority}
-  redirectUri={redirectUri}
-  postLogoutRedirectUri={postLogoutRedirectUri}
-  organizationId={organizationId}
-  projectId={projectId}
+  clientId={zitadelConfig.clientId}
+  authority={zitadelConfig.authority}
+  redirectUri={zitadelConfig.redirectUri}
+  postLogoutRedirectUri={zitadelConfig.postLogoutRedirectUri}
+  organizationId={zitadelConfig.organizationId}
+  projectId={zitadelConfig.projectId}
   operation="logout"
 />

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,10 @@
+export const isZitadelEnabled = import.meta.env.ENABLE_ZITADEL_AUTH === 'true';
+
+export const zitadelConfig = {
+    clientId: import.meta.env.PUBLIC_ZITADEL_CLIENT_ID,
+    authority: import.meta.env.PUBLIC_ZITADEL_AUTHORITY,
+    redirectUri: import.meta.env.PUBLIC_ZITADEL_REDIRECT_URI,
+    postLogoutRedirectUri: import.meta.env.PUBLIC_ZITADEL_LOGOUT_REDIRECT_URI,
+    organizationId: import.meta.env.PUBLIC_ZITADEL_ORGANIZATION_ID,
+    projectId: import.meta.env.PUBLIC_ZITADEL_PROJECT_ID,
+};


### PR DESCRIPTION
- Introduced feature flag `ENABLE_ZITADEL_AUTH` to enable/disable ZITADEL authentication.
- Added `.env.example` with placeholders for environment variables.
- Updated logic to conditionally include ZITADEL authentication based on the feature flag.
- Improved documentation with instructions for setting up environment variables.